### PR TITLE
bugfix/QuikklyScanViewDefinition

### DIFF
--- a/Quikkly.js
+++ b/Quikkly.js
@@ -25,7 +25,7 @@ export class QuikklyView extends Component {
       this.props.onScanCode(event.nativeEvent)
     }
   }
-  
+
   render() {
     return (
       <QuikklyScanView
@@ -35,8 +35,6 @@ export class QuikklyView extends Component {
     );
   }
 }
-
-const QuikklyScanView = requireNativeComponent("QuikklyScanView", QuikklyView)
 
 export const QuikklyError = {
   NO_CONTEXT: "QuikklyNoContext",


### PR DESCRIPTION
This is causing a JS error `Identifier 'QuikklyScanView' has already been declared`

![Screen Shot 2019-07-11 at 9 59 03 AM](https://user-images.githubusercontent.com/4753246/61065906-3639f500-a3ca-11e9-84af-cbd865f0a28c.png)
